### PR TITLE
Add brew, apt providers & move header references to shim

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "CFreeType"
+    name: "CFreeType",
+    pkgConfig: "freetype2",
+    providers: [.Brew("freetype2"), .Apt("freetype2")]
 )

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,7 +1,5 @@
 module CFreeType [system] {
-    header "/usr/include/freetype2/ft2build.h"
-    header "/usr/include/freetype2/freetype.h"
-    header "/usr/include/freetype2/tttables.h"
+    header "shim.h"
     link "freetype"
     export *
 }

--- a/shim.h
+++ b/shim.h
@@ -1,0 +1,4 @@
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include <freetype/freetype.h>
+#include <freetype/tttables.h>


### PR DESCRIPTION
Allows using Cairo with Swift 3.1 on macOS Sierra 10.12.4 with Homebrew. Probably solves #1.

Contains changes originally created by @astrotuna201 (kudos).