### PR TITLE
Compatibility with current versions of FreeType

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,5 +6,5 @@ import PackageDescription
 let package = Package(
     name: "CFreeType",
     pkgConfig: "freetype2",
-    providers: [.brew(["freetype2"]), .apt(["libfreetype2-dev"])]
+    providers: [.brew(["freetype"]), .apt(["libfreetype2-dev"])]
 )

--- a/shim.h
+++ b/shim.h
@@ -3,6 +3,9 @@
 #ifdef __linux__
 #include <freetype/freetype.h>
 #include <freetype/tttables.h>
+#elif defined(__APPLE__)
+#include <freetype/freetype.h>
+#include <freetype/tttables.h>
 #else
 #include <freetype.h>
 #include <tttables.h>


### PR DESCRIPTION
- There isn't formulae named `freetype2` in brew. Pleas refer to [brew documentation for `freetype` formulae](https://formulae.brew.sh/formula/freetype). It clearly specifies version 2, even though package doesn't have 2 in name.

- Location of header files probably changed. I have tried it on two independent devices with current Mac OS and on both `freetype.h` and `tttables.h` are located in `${includedir}/freetype2/freetype/` folder.

Without those changes library does not compile. I would like to suggest tagging version having mentioned changes as 2.0.0 since it is not backwards compatibile. 